### PR TITLE
debug(tasks): 添加调试信息以便于排查爬虫任务触发问题

### DIFF
--- a/fastapi_backend/app/routes/tasks.py
+++ b/fastapi_backend/app/routes/tasks.py
@@ -114,6 +114,8 @@ async def trigger_crawl_task(
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/actions/workflows/{workflow_id}/dispatches"
 
         print(f"url===>: {url}")
+        print(f"github_payload===>: {github_payload}")
+        print(f"headers===>: {headers}")
         
         response = requests.post(url, json=github_payload, headers=headers)
         


### PR DESCRIPTION
- 在触发爬虫任务的 API 路由中，增加了对 GitHub 请求负载和请求头的打印，便于后续调试和问题排查。