### PR TITLE
fix(ci): 更新 GITHUB_TOKEN 环境变量为 ACTIONS_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy-to-aliyun.yml
+++ b/.github/workflows/deploy-to-aliyun.yml
@@ -74,7 +74,7 @@ jobs:
             VERIFICATION_SECRET_KEY=${{ secrets.VERIFICATION_SECRET_KEY }}
             # App settings
             CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN }}
             GITHUB_REPO_OWNER=JunJD
             GITHUB_REPO_NAME=xiuer-spider
             GITHUB_WORKFLOW_ID=170912099


### PR DESCRIPTION
- 修改 GitHub Actions 部署脚本中的 GITHUB_TOKEN 环境变量为 ACTIONS_GITHUB_TOKEN，以确保在部署过程中正确引用 GitHub Actions 的权限。