### PR TITLE
feat(docker): 在生产环境配置中添加数据库服务并更新网络设置

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,21 @@
 {
     "cSpell.words": [
+        "asyncpg",
         "autoform",
         "cmdk",
+        "datefmt",
         "dummyhash",
         "fastapi",
+        "levelname",
         "makemigrations",
+        "mydatabase",
+        "NOTSET",
         "Nuqs",
         "onupdate",
+        "qualname",
+        "sqlalchemy",
         "testdatabase",
+        "venv",
         "xiuer"
     ]
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,4 +25,7 @@ services:
       - backend
       - frontend
     networks:
-      - my_network 
+      - my_network
+  db:
+    ports:
+      - "5431:5432" 


### PR DESCRIPTION
- 在 docker-compose.prod.yml 中添加 db 服务，映射数据库端口为 5431:5432。
- 更新网络设置，确保服务间的连接正常。